### PR TITLE
Fix for snipping tool not being able to capture accurate image due to Window's scaling factor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 __pycache__
+Lib/
+Scripts/
+pyvenv.cfg

--- a/helpers/screen_reader.py
+++ b/helpers/screen_reader.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import pytesseract
 import pyttsx3
+import ctypes
 from PIL import ImageGrab
 from PyQt6 import QtWidgets, QtCore, QtGui
 from deep_translator import (GoogleTranslator,
@@ -13,14 +14,16 @@ from deep_translator import (GoogleTranslator,
 
 pytesseract.pytesseract.tesseract_cmd = r"E:\Tesseract OCR\tesseract.exe"
 
+scaleFactor = ctypes.windll.shcore.GetScaleFactorForDevice(0) / 100
+
 class Worker(QtCore.QObject):
     def __init__(self, snip_window, image_lang_code, trans_lang_code, is_text2speech_enabled, ui, translator_engine,
                  img_lang, trans_lang):
         super().__init__()
-        self.x1 = min(snip_window.begin.x(), snip_window.end.x())
-        self.y1 = min(snip_window.begin.y(), snip_window.end.y())
-        self.x2 = max(snip_window.begin.x(), snip_window.end.x())
-        self.y2 = max(snip_window.begin.y(), snip_window.end.y())
+        self.x1 = min(snip_window.begin.x(), snip_window.end.x()) * scaleFactor
+        self.y1 = min(snip_window.begin.y(), snip_window.end.y()) * scaleFactor
+        self.x2 = max(snip_window.begin.x(), snip_window.end.x()) * scaleFactor
+        self.y2 = max(snip_window.begin.y(), snip_window.end.y()) * scaleFactor
         self.image_lang_code = image_lang_code
         self.trans_lang_code = trans_lang_code
         self.is_text2speech_enabled = is_text2speech_enabled
@@ -38,7 +41,7 @@ class Worker(QtCore.QObject):
         while self.running:
             img = ImageGrab.grab(bbox=(self.x1, self.y1, self.x2, self.y2))
             img = cv2.cvtColor(np.array(img), cv2.COLOR_BGR2GRAY)
-            # cv2.imwrite('img.jpg', img)
+            # cv2.imwrite('img.jpg', img)     # for debugging
 
             new_extracted_text = pytesseract.image_to_string(img, lang=self.image_lang_code).strip()
             new_extracted_text = " ".join(new_extracted_text.split())

--- a/helpers/screen_reader.py
+++ b/helpers/screen_reader.py
@@ -11,8 +11,7 @@ from deep_translator import (GoogleTranslator,
                              MyMemoryTranslator,
                              LingueeTranslator)
 
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
-
+pytesseract.pytesseract.tesseract_cmd = r"E:\Tesseract OCR\tesseract.exe"
 
 class Worker(QtCore.QObject):
     def __init__(self, snip_window, image_lang_code, trans_lang_code, is_text2speech_enabled, ui, translator_engine,
@@ -39,6 +38,7 @@ class Worker(QtCore.QObject):
         while self.running:
             img = ImageGrab.grab(bbox=(self.x1, self.y1, self.x2, self.y2))
             img = cv2.cvtColor(np.array(img), cv2.COLOR_BGR2GRAY)
+            # cv2.imwrite('img.jpg', img)
 
             new_extracted_text = pytesseract.image_to_string(img, lang=self.image_lang_code).strip()
             new_extracted_text = " ".join(new_extracted_text.split())

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Only works when your Windows scaling is set to 100% (other scalings might cause issues)
 
 import sys
 import ctypes

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Only works when your Windows scaling is set to 100% (other scalings might cause issues)
 
 import sys
 import ctypes


### PR DESCRIPTION
**Issue encountered:** 

- The screen snippet created is inaccurate if Windows have other scaling factors other than 100%, which causes the translator to translate wrong information

**Solution**

- Used Python's `ctypes` library to get Window's current scaling factor and apply them to calculate the snippet image x and y-coordinates.

**Notes before merging**

- Remember to change `tesseract_cmd` back to the correct / default location.
- Remember to remove the commented out debugging lines.
